### PR TITLE
Improve validation, handle empty `options.phrases`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ The text to be obscured.
 
 The specific phrases to be obscured. If not specified or empty, the entire text will be obscured.
 
+Each phrase must be **less than or equal to 30 characters** and only contain the following characters:
+
+- Alphabets (`a-z`, `A-Z`)
+- Numbers (`0-9`)
+- Spaces (` `)
+- Hyphens (`-`)
+- Underscores (`_`)
+- Apostrophes (`'`)
+- Forward slashes (`/`)
+
 ##### caseSensitive
 
 - Type: `boolean`

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The text to be obscured.
 - Type: `string[]`
 - Required: `false`
 
-The specific phrases to be obscured. If not specified, the whole text will be obscured.
+The specific phrases to be obscured. If not specified or empty, the entire text will be obscured.
 
 ##### caseSensitive
 
@@ -92,7 +92,12 @@ Whether to obscure in a case-sensitive manner.
 
 The character set that will be used for obfuscation. Put the **name of the** [**built-in character sets**](#character-sets) or a **custom character set objects**.
 
-The valid custom character set object must be an object that **each key is a single character** and **each value is an array of single characters** that will be used to replace the key. See the example below.
+The valid custom character set must be an object that contains key-value pairs where:
+
+- The **key** is the character to be replaced. It must be a **single alphabet character** (`a-z`, `A-Z`).
+- The **value** is an array of characters that will be used to replace the key. It must be an array of **any single characters** other than [control characters](https://unicodeplus.com/category/Cc).
+
+See the example below.
 
 ```js
 const customCharSet = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,16 @@ export function isCharSetValid(charSet: object): boolean {
 }
 
 /**
+ * Check if the given phrase is valid.
+ * @param phrase The phrase to check.
+ */
+export function isPhraseValid(phrase: string): boolean {
+  return typeof phrase === 'string'
+    && /^[a-zA-Z0-9 \-_'/]+$/.test(phrase)
+    && phrase.trim().length > 0 && phrase.length <= 30;
+}
+
+/**
  * Merge multiple charsets.
  * @param charSets The names of built-in charset or custom charsets to merge.
  * @returns The merged charset.
@@ -120,8 +130,8 @@ export type Options = {
 
 /**
  * @param options The options.
- * @throws {ValidationError} If the given built-in charset name is invalid
- * or if the given custom charset is invalid.
+ * @throws {ValidationError} If the given built-in charset name,
+ * the given custom charset, or if the given phrases are invalid.
  */
 export default function wisely(options: Options): string {
   const charSet = mergeCharSets(...(options.charSets ?? ['latin']));
@@ -135,8 +145,13 @@ export default function wisely(options: Options): string {
   }
 
   let res = options.text;
-  for (const t of options.phrases) {
-    const regex = new RegExp(`\\b${t}\\b`, options.caseSensitive ? 'g' : 'gi');
+  for (const phrase of options.phrases) {
+    // Validating the phrase
+    if (!isPhraseValid(phrase)) {
+      throw new ValidationError(`Invalid phrase: ${phrase}`);
+    }
+
+    const regex = new RegExp(`\\b${phrase.trim()}\\b`, options.caseSensitive ? 'g' : 'gi');
 
     for (const m of options.text.matchAll(regex)) {
       const [match] = m;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -74,10 +74,16 @@ describe('mergeCharSets', () => {
   });
 
   test('invalid custom charSets', () => {
-    expect(() => mergeCharSets({ aa: ['b', 'c', 'd'] })).toThrow();
+    expect(() => mergeCharSets({ aa: ['b'] })).toThrow();
     expect(() => mergeCharSets({ a: ['bc'] })).toThrow();
-    expect(() => mergeCharSets({ a: ['b', 'c', ''] })).toThrow();
-    expect(() => mergeCharSets({ a: ['b', 'c', 'd', ''] })).toThrow();
+    expect(() => mergeCharSets({ a: [''] })).toThrow();
+    expect(() => mergeCharSets({ a: ['b', ''] })).toThrow();
+    expect(() => mergeCharSets({ 1: ['a'] })).toThrow();
+    expect(() => mergeCharSets({ '!': ['a'] })).toThrow();
+    // Not contains control characters
+    expect(() => mergeCharSets({
+      a: ['\u0000', '\u0001', '\u001f', '\u007f', '\u0080', '\u009f'],
+    })).toThrow();
   });
 });
 
@@ -132,7 +138,7 @@ describe('wisely', () => {
   });
 
   test('empty phrases', () => {
-    expect(wisely({ text, phrases: [] })).toEqual(text);
+    expect(wisely({ text, phrases: [] })).not.toEqual(text);
   });
 
   test.each<{ testText: string, charSets: Options['charSets'], contains: string, notContains: string }>([

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -141,6 +141,19 @@ describe('wisely', () => {
     expect(wisely({ text, phrases: [] })).not.toEqual(text);
   });
 
+  test('with invalid phrases', () => {
+    expect(() => wisely({ text, phrases: [''] })).toThrow();
+    expect(() => wisely({ text, phrases: [' '] })).toThrow();
+    expect(() => wisely({ text, phrases: [' '.repeat(10)] })).toThrow();
+    expect(() => wisely({ text, phrases: ['\n'] })).toThrow();
+    expect(() => wisely({ text, phrases: ['a\n'] })).toThrow();
+    expect(() => wisely({ text, phrases: ['\t'] })).toThrow();
+    expect(() => wisely({ text, phrases: ['a\t'] })).toThrow();
+    expect(() => wisely({ text, phrases: ['a'.repeat(31)] })).toThrow();
+    expect(() => wisely({ text, phrases: ['th!s symbo|'] })).toThrow();
+    expect(() => wisely({ text, phrases: ['\\'] })).toThrow();
+  });
+
   test.each<{ testText: string, charSets: Options['charSets'], contains: string, notContains: string }>([
     {
       charSets: ['latin-1'],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

- Crash when the `options.phrases` contains `[`, `{`, or `(` item.
  ```
  Invalid regular expression: /\b[\b/: Unterminated character class
  ```
- Validation for `options.charSets` only about the character length.
- When `options.phrases` is `[]`, the result is same with the text input (nothing changes).

## What is the new behavior?

- Tighten validation for `options.phrases` by only allowing alphabets, numbers, spaces, and some symbols (`-_'/`).
- Tighten validation for `options.charSets` by only allowing alphabets for the **key** and prohibiting the use of [control characters](https://unicodeplus.com/category/Cc) for the item of the **value**.
- Now, `options.phrases` with `undefined` and `[]` are same (will obscures the whole text).

## Other information

None
